### PR TITLE
Use project minSdkVersion and default to 16

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -1,3 +1,7 @@
+def safeExtGet(prop, fallback) {
+    rootProject.ext.has(prop) ? rootProject.ext.get(prop) : fallback
+}
+
 buildscript {
     repositories {
         google()
@@ -28,7 +32,7 @@ android {
     buildToolsVersion "29.0.3"
 
     defaultConfig {
-        minSdkVersion 16
+        minSdkVersion safeExtGet('minSdkVersion', 16) 
         targetSdkVersion 30
         versionCode 1
         versionName "1.0"


### PR DESCRIPTION
Current build is failing with the following error: 

```bash
Error:
        uses-sdk:minSdkVersion 16 cannot be smaller than version 21 declared in library [com.facebook.react:react-native:0.66.5]
```

This MR simply allows to set the minSdkVersion from the project root