### PR TITLE
Replace jcenter with mavenCentral and remove old maven.google.com

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -1,7 +1,7 @@
 buildscript {
     repositories {
         google()
-        jcenter()
+        mavenCentral()
     }
 
     dependencies {
@@ -15,8 +15,6 @@ rootProject.allprojects {
             url "https://github.com/Gainsight/px-android/raw/main/"
         }
         google()
-        jcenter()
-        maven { url 'https://maven.google.com' }
         mavenCentral()
     }
 }


### PR DESCRIPTION
- We should no longer use jcenter() according to [JCenter migration](https://developer.android.com/build/jcenter-migration).
- Remove old 'maven.google.com' url as google() is an alias and more recommended today

closes #5
